### PR TITLE
Run program bug fixes, vol. #2

### DIFF
--- a/TODO
+++ b/TODO
@@ -241,6 +241,7 @@
 ** For proper incremental redefinitions, systems probably need to
    depend-on (load-asd-op . primary-system) which itself will
    depend-on all the load-op of defsystem-depends-on in that file.
+   https://bugs.launchpad.net/asdf/+bug/1500578
 
 * Include some ABL test for stassats's (now obsolete?) thing:
    (asdf:enable-asdf-binary-locations-compatibility

--- a/test/asdf-pathname-test.script
+++ b/test/asdf-pathname-test.script
@@ -364,7 +364,7 @@
                                           :direction :output
                                           :if-exists :supersede :if-does-not-exist :create)
              (setup-asdftest-logical-host :root root)
-             #+(and asdf-test-logical-pathname (not clisp))
+             #+(and asdf-test-logical-pathname)
              (assert-pathname-equal
               (make-pathname :host "ASDFTEST" :directory '(:absolute "system2" "module4")
                              :name nil :type nil)

--- a/test/asdf-pathname-test.script
+++ b/test/asdf-pathname-test.script
@@ -419,9 +419,9 @@
     (clear-system "test-system")))
 
 (defun test-pathname-parsing ()
-  #-(or allegro clisp clozure cmu ecl lispworks mkcl sbcl)
+  #-(or allegro clisp clozure cmucl ecl lispworks mkcl sbcl)
   (DBG "Can't test pathname parsing: this lisp lacks SETENV support.")
-  #+(or allegro clisp clozure cmu ecl lispworks mkcl sbcl)
+  #+(or allegro clisp clozure cmucl ecl lispworks mkcl sbcl)
   (let ((old-config (uiop:getenvp "XDG_CONFIG_DIRS"))
         (old-home-config (uiop:getenvp "XDG_CONFIG_HOME")))
     (unwind-protect

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -242,8 +242,8 @@ case "$lisp" in
     eval="--eval" ;;
   clasp)
     command="${CLASP:-clasp}"
-    flags=""
-    eval="" ;;
+    flags="--norc --noinit"
+    eval="--eval" ;;
   clisp)
     command="${CLISP:-clisp}"
     flags="-norc --silent -ansi -I "

--- a/test/script-support.lisp
+++ b/test/script-support.lisp
@@ -38,9 +38,9 @@ Some constraints:
 #+(and ecl (not ecl-bytecmp)) (require :cmp)
 
 (declaim (optimize (speed 2) (safety #-gcl 3 #+gcl 0) #-(or allegro gcl genera) (debug 3)
-                   #+(or cmu scl) (c::brevity 2)))
+                   #+(or cmucl scl) (c::brevity 2)))
 (proclaim '(optimize (speed #-gcl 2 #+gcl 1) (safety #-gcl 3 #+gcl 0) #-(or allegro gcl genera) (debug 3)
-                     #+(or cmu scl) (c::brevity 2) #+(or cmu scl) (ext:inhibit-warnings 3)))
+                     #+(or cmucl scl) (c::brevity 2) #+(or cmucl scl) (ext:inhibit-warnings 3)))
 
 (defparameter *trace-symbols*
   `(;; If you want to trace some stuff while debugging ASDF,
@@ -257,7 +257,7 @@ Some constraints:
       #+(or clasp ecl) (or #+ecl-bytecmp :ecl_bytecodes :ecl)
       #+clisp :clisp
       #+clozure :ccl
-      #+cmu :cmucl
+      #+cmucl :cmucl
       #+corman :cormanlisp
       #+digitool :mcl
       #+gcl :gcl
@@ -338,7 +338,7 @@ Some constraints:
   #+clisp (ext:quit code)
   #+clozure (ccl:quit code)
   #+cormanlisp (win32:exitprocess code)
-  #+(or cmu scl) (unix:unix-exit code)
+  #+(or cmucl scl) (unix:unix-exit code)
   #+gcl (system:quit code)
   #+genera (error "You probably don't want to Halt the Machine. (code: ~S)" code)
   #+lispworks (lispworks:quit :status code :confirm nil :return nil :ignore-errors-p t)
@@ -349,7 +349,7 @@ Some constraints:
              (cond
                (exit `(,exit :code code :abort t))
                (quit* `(,quit* :unix-status code :recklessly-p t))))
-  #-(or abcl allegro clasp clisp clozure cmu ecl gcl genera lispworks mcl mkcl sbcl scl xcl)
+  #-(or abcl allegro clasp clisp clozure cmucl ecl gcl genera lispworks mcl mkcl sbcl scl xcl)
   (error "~S called with exit code ~S but there's no quitting on this implementation" 'quit code))
 
 
@@ -446,7 +446,7 @@ is bound, write a message and exit on an error.  If
                  #+sbcl
                  ((or sb-c::simple-compiler-note sb-kernel:redefinition-warning)
                    #'muffle-warning)
-                 #-(or cmu scl)
+                 #-(or cmucl scl)
                  ;; style warnings shouldn't abort the compilation [2010/02/03:rpg]
                  (style-warning
                    #'(lambda (w)
@@ -487,7 +487,7 @@ is bound, write a message and exit on an error.  If
             ;; CMUCL: ?
             ;; ECL 11.1.1 has spurious warnings, same with XCL 0.0.0.291.
             ;; SCL has no warning but still raises the warningp flag since 2.20.15 (?)
-            #+(or clasp clisp cmu ecl scl xcl) (good :expected-style-warnings)
+            #+(or clasp clisp cmucl ecl scl xcl) (good :expected-style-warnings)
             (and upgradep (good :unexpected-style-warnings))
             (bad :unexpected-style-warnings)))
           (t (good :success)))))))

--- a/test/test-deferred-warnings.script
+++ b/test/test-deferred-warnings.script
@@ -108,12 +108,12 @@
      (:no-error (&rest values) (DBG :ustdf1 values) nil))))
 
 (errors #+(or allegro clozure) compile-file-error
-        #+(or cmu scl) compile-warned-error
+        #+(or cmucl scl) compile-warned-error
         #+sbcl compile-failed-error
         (let ((*compile-file-warnings-behaviour* :error))
           (load-system :undefined-variables :force t)))
 (errors #+(or allegro clozure) compile-file-error
-        #+(or cmu scl) null
+        #+(or cmucl scl) null
         #+sbcl compile-failed-error
         (let ((*compile-file-warnings-behaviour* :warning))
           (load-system :undefined-variables :force t)))

--- a/test/test-logical-pathname.script
+++ b/test/test-logical-pathname.script
@@ -48,6 +48,9 @@
 (load-system :test-logical-pathname :force t)
 
 #+abcl (leave-test "ABCL translates logical pathnames in *LOAD-PATHNAME*" 0)
+#+clisp
+(unless (version<= "2.50" (first (split-string (lisp-implementation-version) :separator "-+ ")))
+  (leave-test "CLISP 2.49 translates logical pathnames in *LOAD-PATHNAME*" 0))
 
 (defparameter sys (find-system :test-logical-pathname))
 (assert (logical-pathname-p (component-pathname sys)))

--- a/test/test-make-build.script
+++ b/test/test-make-build.script
@@ -8,6 +8,8 @@
 (DBG "build sample-system. Should load from sample-system/")
 (setf *central-registry* (list (subpathname *test-directory* "sample-system/")))
 
+#+lispworks (lispworks:load-all-patches)
+
 (make-build 'sample-system
             :type :program :monolithic t
             #+ecl :epilogue-code #+ecl '(println "blue sky"))

--- a/test/test-make-build.script
+++ b/test/test-make-build.script
@@ -1,6 +1,6 @@
 ;;; -*- Lisp -*-
 
-(unless (or #+(or (and clisp os-unix) clozure cmu
+(unless (or #+(or (and clisp os-unix) clozure cmucl
                   (and ecl (not ecl-bytecmp) (not os-macosx)) lispworks mkcl sbcl scl) t)
   (DBG "Creating executables is not supported on your CL implementation")
   (leave-test "Skipping test" 0))

--- a/test/test-program.script
+++ b/test/test-program.script
@@ -1,7 +1,7 @@
 ;;; -*- Lisp -*-
 (DBG :foo (current-lisp-file-pathname))
 
-(unless (or #+(or allegro (and clisp os-unix) clozure cmu (and ecl (not ecl-bytecmp)) lispworks mkcl sbcl scl) t)
+(unless (or #+(or allegro (and clisp os-unix) clozure cmucl (and ecl (not ecl-bytecmp)) lispworks mkcl sbcl scl) t)
   (DBG "Creating images is not supported on your CL implementation")
   (leave-test "Skipping test" 0))
 
@@ -44,7 +44,7 @@
   (delete-file-if-exists img)
   (DBG "- first create an executable image")
   (make-hello-world 'image)
-  #+cmu
+  #+cmucl
   (unless (probe-file* img)
     (leave-test "CMUCL seemingly can't find the 32-bit compiler and libraries required to dump images. Aborting test." 0))
   (assert (probe-file* img) () "Can't find image file ~S" img)
@@ -81,7 +81,7 @@
 (progn
   (DBG "test program-op")
   (unless (or #+(or clisp clozure (and ecl (not ecl-bytecmp)) lispworks mkcl sbcl) t
-              #+cmu nil ;; uncomment if you have 32-bit gcc support - or can autodetect
+              #+cmucl nil ;; uncomment if you have 32-bit gcc support - or can autodetect
               #+clisp (version-satisfies
                        (first (split-string (lisp-implementation-version) :separator " "))
                        "2.48"))

--- a/test/test-run-program.script
+++ b/test/test-run-program.script
@@ -177,14 +177,14 @@ Testing run-program
   (assert-equal (nl "Hello World") (run-program "echo Hello World" :output :string))
 
   (DBG "Test that run-program fails properly with an empty program string")
-  #+(or clozure (and allegro os-unix) cmu (and lispworks os-unix) sbcl scl)
+  #+(or clozure (and allegro os-unix) cmucl (and lispworks os-unix) sbcl scl)
   (signals error (run-program '("") :output :lines))
 
   (DBG "An empty string itself is ok since it is passed to the shell.")
   (assert-equal "" (run-program "" :output :string))
 
   (DBG "Test that run-program fails properly with a nil program list")
-  #+(or clozure (and allegro os-unix) cmu sbcl scl)
+  #+(or clozure (and allegro os-unix) cmucl sbcl scl)
   (signals error (run-program nil :output :lines))
 
   (DBG "Test that run-program fails properly when the executable doesn't exist.")

--- a/test/test-undeferred-warnings.script
+++ b/test/test-undeferred-warnings.script
@@ -26,12 +26,12 @@
 ;; SCL and XCL not actually tested
 (format t "Check for proper errors on warning.~%")
 (errors #+(or abcl allegro clisp clozure (and ecl (not ecl-bytecmp)) lispworks mkcl xcl) compile-file-error
-        #+(or cmu (and ecl ecl-bytecmp) gcl sbcl scl) null
+        #+(or cmucl (and ecl ecl-bytecmp) gcl sbcl scl) null
         (let ((*compile-file-warnings-behaviour* :error))
           (load-system :undefined-variables :force t)))
 (format t  "Check for proper warnings on warning.~%")
 (errors #+(or abcl allegro clisp clozure (and ecl (not ecl-bytecmp)) lispworks mkcl xcl) compile-file-error
-        #+(or cmu (and ecl ecl-bytecmp) gcl sbcl scl) null
+        #+(or cmucl (and ecl ecl-bytecmp) gcl sbcl scl) null
         (let ((*compile-file-warnings-behaviour* :warning))
           (load-system :undefined-variables :force t)))
 (format t "check for undefined variable warnings to not fail a build.~%")

--- a/test/test3.script
+++ b/test/test3.script
@@ -8,7 +8,7 @@
 (DBG "should load file1 but not file2")
 
 ;;; Use REQUIRE where we boast integration, load-system where not.
-(if (or #+(or abcl clozure cmu ecl mkcl sbcl) t
+(if (or #+(or abcl clozure cmucl ecl mkcl sbcl) t
         #+clisp (find-symbol* '#:*module-provider-functions* :custom nil))
     (funcall 'require :test3)
     (load-system :test3))

--- a/tools/install-asdf.lisp
+++ b/tools/install-asdf.lisp
@@ -62,13 +62,13 @@ a command-line executable for LispWorks this way:
   #+(or clasp ecl mkcl) #p"sys:"
   #+clisp (subpathname custom:*lib-directory* "asdf/")
   #+clozure #p"ccl:tools;"
-  #+cmu #p"modules:asdf/"
+  #+cmucl #p"modules:asdf/"
   #+gcl (subpathname system:*system-directory* "../modules/")
   #+lispworks (system:lispworks-dir "load-on-demand/utilities/")
   #+sbcl (subpathname (sb-int:sbcl-homedir-pathname) "contrib/")
   #+scl #p"file://modules/"
   #+xcl ext:*xcl-home*
-  #-(or allegro clasp clisp clozure cmu ecl gcl lispworks mkcl sbcl scl xcl)
+  #-(or allegro clasp clisp clozure cmucl ecl gcl lispworks mkcl sbcl scl xcl)
   (error "module-directory not implemented on ~A" (implementation-type)))
 
 (defun module-fasl (name)
@@ -81,9 +81,9 @@ a command-line executable for LispWorks this way:
                (t -1)))))
     (first (sort (directory (merge-pathnames* (strcat name ".*") (module-directory)))
                  #'> :key #'pathname-key)))
-  #+(or clasp clisp clozure cmu ecl gcl lispworks mkcl sbcl scl xcl)
+  #+(or clasp clisp clozure cmucl ecl gcl lispworks mkcl sbcl scl xcl)
   (compile-file-pathname (subpathname (truename (module-directory)) name :type "lisp"))
-  #-(or allegro clasp clisp clozure cmu ecl gcl lispworks mkcl sbcl scl xcl)
+  #-(or allegro clasp clisp clozure cmucl ecl gcl lispworks mkcl sbcl scl xcl)
   (error "Not implemented on ~A" (implementation-type)))
 
 (defun uiop-module-fasl () (module-fasl "uiop"))
@@ -154,7 +154,7 @@ a command-line executable for LispWorks this way:
 
 #+(or sbcl mkcl)
 (progn (install-uiop-and-asdf-as-modules) (quit))
-#+(or allegro clasp clisp clozure cmu ecl gcl lispworks scl xcl)
+#+(or allegro clasp clisp clozure cmucl ecl gcl lispworks scl xcl)
 (progn (install-asdf-as-module) (quit))
 #+(or abcl cormanlisp genera  mcl mocl)
 (die 2 "Not supported on ~A" (implementation-type))

--- a/uiop/common-lisp.lisp
+++ b/uiop/common-lisp.lisp
@@ -128,6 +128,17 @@
       (scl:send stream :string-out sequence start end)
       sequence)))
 
+#+lispworks
+(eval-when (:load-toplevel :compile-toplevel :execute)
+  ;; lispworks 3 and earlier cannot be checked for so we always assume
+  ;; at least version 4
+  (unless (member :lispworks4 *features*)
+    (pushnew :lispworks5+ *features*)
+    (unless (member :lispworks5 *features*)
+      (pushnew :lispworks6+ *features*)
+      (unless (member :lispworks6 *features*)
+        (pushnew :lispworks7+ *features*)))))
+
 #.(or #+mcl ;; the #$ doesn't work on other lisps, even protected by #+mcl, so we use this trick
       (read-from-string
        "(eval-when (:load-toplevel :compile-toplevel :execute)

--- a/uiop/image.lisp
+++ b/uiop/image.lisp
@@ -51,7 +51,7 @@ before the image dump hooks are called and before the image is dumped.")
     "Functions to call (in order) when before an image is dumped")
 
   (deftype fatal-condition ()
-    `(and serious-condition #+ccl (not ccl:process-reset))))
+    `(and serious-condition #+clozure (not ccl:process-reset))))
 
 ;;; Exiting properly or im-
 (with-upgradability ()

--- a/uiop/lisp-build.lisp
+++ b/uiop/lisp-build.lisp
@@ -770,11 +770,11 @@ it will filter them appropriately."
 (with-upgradability ()
   (defun combine-fasls (inputs output)
     "Combine a list of FASLs INPUTS into a single FASL OUTPUT"
-    #-(or abcl allegro clisp clozure cmu lispworks sbcl scl xcl)
+    #-(or abcl allegro clisp clozure cmucl lispworks sbcl scl xcl)
     (error "~A does not support ~S~%inputs ~S~%output  ~S"
            (implementation-type) 'combine-fasls inputs output)
     #+abcl (funcall 'sys::concatenate-fasls inputs output) ; requires ABCL 1.2.0
-    #+(or allegro clisp cmu sbcl scl xcl) (concatenate-files inputs output)
+    #+(or allegro clisp cmucl sbcl scl xcl) (concatenate-files inputs output)
     #+clozure (ccl:fasl-concatenate output inputs :if-exists :supersede)
     #+lispworks
     (let (fasls)

--- a/uiop/run-program.lisp
+++ b/uiop/run-program.lisp
@@ -582,9 +582,9 @@ It returns a process-info object."
   (defun %wait-process-result (process-info)
     (or (slot-value process-info 'exit-code)
         (let ((process (slot-value process-info 'process)))
+          #-(or allegro clasp clozure cmucl ecl lispworks mkcl sbcl scl)
+          (error "~S not implemented" '%wait-process)
           (when process
-            #-(or allegro clasp clozure cmucl ecl lispworks mkcl sbcl scl)
-            (error "~S not implemented" '%wait-process)
             ;; 1- wait
             #+clozure (ccl::external-process-wait process)
             #+(or cmucl scl) (ext:process-wait process)

--- a/uiop/run-program.lisp
+++ b/uiop/run-program.lisp
@@ -475,9 +475,7 @@ It returns a process-info plist with possible keys:
                   ,if-error-output-exists)
                 #+lispworks `(:save-exit-status t)
                 #+mkcl `(:directory ,(native-namestring directory))
-                #+sbcl `(:search t
-                         :if-output-does-not-exist :create
-                         :if-error-does-not-exist :create)
+                #+sbcl `(:search t)
                 #-sbcl keys
                 #+sbcl (if directory keys (remove-plist-key :directory keys))))))
            (process-info-r ()))

--- a/uiop/run-program.lisp
+++ b/uiop/run-program.lisp
@@ -391,8 +391,8 @@ argument to pass to the internal RUN-PROGRAM"
       ((eql :interactive)
        #+allegro nil
        #+clisp :terminal
-       #+(or clasp clozure cmucl ecl mkcl sbcl scl) t)
-      #+(or allegro clasp clozure cmucl ecl lispworks mkcl sbcl scl)
+       #+(or clozure cmucl ecl mkcl sbcl scl) t)
+      #+(or allegro clozure cmucl ecl lispworks mkcl sbcl scl)
       ((eql :output)
        (if (eq role :error-output)
            :output
@@ -438,10 +438,10 @@ It returns a process-info object."
     (declare (ignorable directory if-input-does-not-exist if-output-exists if-error-output-exists))
     #-(or cmucl ecl mkcl sbcl)
     (assert (not (and wait (member :stream (list input output error-output)))))
-    #-(or allegro clasp clisp clozure cmucl ecl (and lispworks os-unix) mkcl sbcl scl)
+    #-(or allegro clisp clozure cmucl ecl (and lispworks os-unix) mkcl sbcl scl)
     (progn command keys directory
            (error "run-program not available"))
-    #+(or allegro clasp clisp clozure cmucl ecl (and lispworks os-unix) mkcl sbcl scl)
+    #+(or allegro clisp clozure cmucl ecl (and lispworks os-unix) mkcl sbcl scl)
     (let* ((%command (%normalize-command command))
            (%if-output-exists (%normalize-if-exists if-output-exists))
            (%input (%normalize-io-specifier input :input))
@@ -457,7 +457,7 @@ It returns a process-info object."
                         ;; if any of the input, output or error-output is :stream.
                         (assert (eq %error-output :terminal)))
               #-(or allegro mkcl sbcl) (with-current-directory (directory))
-              #+(or allegro clasp clisp ecl lispworks mkcl) (multiple-value-list)
+              #+(or allegro clisp ecl lispworks mkcl) (multiple-value-list)
               (apply
                #+allegro 'excl:run-shell-command
                #+(and allegro os-unix) (coerce (cons (first %command) %command) 'vector)
@@ -543,8 +543,8 @@ It returns a process-info object."
                   #+clozure (ccl:external-process-error-stream process*)
                   #+(or cmucl scl) (ext:process-error process*)
                   #+sbcl (sb-ext:process-error process*))))
-        #+(or clasp ecl mkcl)
-        (destructuring-bind #+(or clasp ecl) (stream code process) #+mkcl (stream process code) process*
+        #+(or ecl mkcl)
+        (destructuring-bind #+ecl (stream code process) #+mkcl (stream process code) process*
           (let ((mode (+ (if (eq input :stream) 1 0) (if (eq output :stream) 2 0))))
             (cond
               ((zerop mode))
@@ -575,7 +575,6 @@ It returns a process-info object."
     (let ((process (slot-value process-info 'process)))
       (declare (ignorable process))
       #+allegro process
-      #+clasp (si:external-process-pid process)
       #+clozure (ccl:external-process-id process)
       #+ecl (ext:external-process-pid process)
       #+(or cmucl scl) (ext:process-pid process)
@@ -583,13 +582,13 @@ It returns a process-info object."
       #+(and lispworks (not lispworks7+)) process
       #+mkcl (mkcl:process-id process)
       #+sbcl (sb-ext:process-pid process)
-      #-(or allegro clasp clozure cmucl ecl mkcl lispworks sbcl scl)
+      #-(or allegro clozure cmucl ecl mkcl lispworks sbcl scl)
       (error "~S not implemented" '%process-info-pid)))
 
   (defun %wait-process-result (process-info)
     (or (slot-value process-info 'exit-code)
         (let ((process (slot-value process-info 'process)))
-          #-(or allegro clasp clozure cmucl ecl lispworks mkcl sbcl scl)
+          #-(or allegro clozure cmucl ecl lispworks mkcl sbcl scl)
           (error "~S not implemented" '%wait-process)
           (when process
             ;; 1- wait
@@ -604,7 +603,7 @@ It returns a process-info object."
                                (or signal exit-code))
                    #+clozure (nth-value 1 (ccl:external-process-status process))
                    #+(or cmucl scl) (ext:process-exit-code process)
-                   #+(or clasp ecl) (nth-value 1 (ext:external-process-wait process t))
+                   #+ecl (nth-value 1 (ext:external-process-wait process t))
                    #+lispworks
                    ;; a signal is only returned on LispWorks 7+
                    (multiple-value-bind (exit-code signal)

--- a/uiop/stream.lisp
+++ b/uiop/stream.lisp
@@ -557,7 +557,7 @@ If a string, repeatedly read and evaluate from it, returning the last values."
     "Call a THUNK with stream and/or pathname arguments identifying a temporary file.
 
 The temporary file's pathname will be based on concatenating
-PREFIX (defaults to \"uiop\"), a random alphanumeric string,
+PREFIX (or \"tmp\" if it's NIL), a random alphanumeric string,
 and optional SUFFIX (defaults to \"-tmp\" if a type was provided)
 and TYPE (defaults to \"tmp\", using a dot as separator if not NIL),
 within DIRECTORY (defaulting to the TEMPORARY-DIRECTORY) if the PREFIX isn't absolute.

--- a/uiop/uiop.asd
+++ b/uiop/uiop.asd
@@ -9,8 +9,8 @@
   (handler-bind (((or
                    #+allegro simple-warning
                    #+clozure ccl:compiler-warning
-                   #+cmu kernel:simple-style-warning
-                   #-(or allegro clozure cmu) warning)
+                   #+cmucl kernel:simple-style-warning
+                   #-(or allegro clozure cmucl) warning)
                    #'muffle-warning))
     (funcall thunk)))
 


### PR DESCRIPTION
A collection of fixes that does not rely on the introduction of new condition classes.

The exit code code handling is improved but still rather messy with these changes. mkcl will still return a symbol if a process dies in response to a signal, and signal 15 may lead to exit status 143 or 15. This will be addressed in a follow-up merge request.